### PR TITLE
Implement message retrieval GUI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+.idea/
+.vscode/
+.DS_Store
+
+__debug*
+amqps-client

--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@ This application provides a small graphical interface for connecting to an AMQPS
 - "Connect" button that attempts an mTLS connection using the `go-amqp` library
 - Connection result is displayed inside the window
 - The `.p12` file is converted to PEM at runtime to load the certificate chain
+- Fields to provide a queue name and number of messages to fetch
+- "Retrieve" button fetches messages without acknowledging them
+- Buttons to acknowledge or release all fetched messages
 
 ## Building
 

--- a/main.go
+++ b/main.go
@@ -6,6 +6,8 @@ import (
 	"encoding/pem"
 	"fmt"
 	"os"
+	"strconv"
+	"strings"
 
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/app"
@@ -16,14 +18,17 @@ import (
 	"golang.org/x/crypto/pkcs12"
 )
 
-func connect(url, p12Path, password string) error {
+var conn *amqp.Conn
+var retrievedMsgs []*amqp.Message
+
+func connect(url, p12Path, password string) (*amqp.Conn, error) {
 	data, err := os.ReadFile(p12Path)
 	if err != nil {
-		return fmt.Errorf("failed to read p12 file: %w", err)
+		return nil, fmt.Errorf("failed to read p12 file: %w", err)
 	}
 	blocks, err := pkcs12.ToPEM(data, password)
 	if err != nil {
-		return fmt.Errorf("failed to decode p12: %w", err)
+		return nil, fmt.Errorf("failed to decode p12: %w", err)
 	}
 	var pemData []byte
 	for _, b := range blocks {
@@ -31,18 +36,18 @@ func connect(url, p12Path, password string) error {
 	}
 	cert, err := tls.X509KeyPair(pemData, pemData)
 	if err != nil {
-		return fmt.Errorf("failed to parse key pair: %w", err)
+		return nil, fmt.Errorf("failed to parse key pair: %w", err)
 	}
 	tlsConfig := &tls.Config{
 		InsecureSkipVerify: true,
 		Certificates:       []tls.Certificate{cert},
 		MinVersion:         tls.VersionTLS12,
 	}
-	_, err = amqp.Dial(context.Background(), url, &amqp.ConnOptions{TLSConfig: tlsConfig})
+	conn, err := amqp.Dial(context.Background(), url, &amqp.ConnOptions{TLSConfig: tlsConfig})
 	if err != nil {
-		return err
+		return nil, err
 	}
-	return nil
+	return conn, nil
 }
 
 func main() {
@@ -59,15 +64,87 @@ func main() {
 
 	statusLabel := widget.NewLabel("")
 
+	queueEntry := widget.NewEntry()
+	queueEntry.SetPlaceHolder("queue name")
+
+	numEntry := widget.NewEntry()
+	numEntry.SetText("10")
+
+	msgDisplay := widget.NewMultiLineEntry()
+	msgDisplay.Disable()
+
+	ackBtn := widget.NewButton("Acknowledge all", func() {
+		go func() {
+			for _, m := range retrievedMsgs {
+				_ = m.Accept(context.Background())
+			}
+			retrievedMsgs = nil
+			msgDisplay.SetText("")
+		}()
+	})
+	ackBtn.Disable()
+
+	releaseBtn := widget.NewButton("Release all", func() {
+		go func() {
+			for _, m := range retrievedMsgs {
+				_ = m.Release(context.Background())
+			}
+			retrievedMsgs = nil
+			msgDisplay.SetText("")
+		}()
+	})
+	releaseBtn.Disable()
+
 	connectBtn := widget.NewButton("Connect", func() {
 		statusLabel.SetText("Connecting...")
 		go func() {
-			err := connect(urlEntry.Text, p12Entry.Text, passEntry.Text)
+			var err error
+			conn, err = connect(urlEntry.Text, p12Entry.Text, passEntry.Text)
 			if err != nil {
 				statusLabel.SetText(fmt.Sprintf("Connection failed: %v", err))
 			} else {
 				statusLabel.SetText("Connected successfully")
+				ackBtn.Enable()
+				releaseBtn.Enable()
 			}
+		}()
+	})
+
+	retrieveBtn := widget.NewButton("Retrieve", func() {
+		if conn == nil {
+			statusLabel.SetText("Not connected")
+			return
+		}
+		num, err := strconv.Atoi(numEntry.Text)
+		if err != nil {
+			statusLabel.SetText("Invalid number")
+			return
+		}
+		go func() {
+			sess, err := conn.NewSession(context.Background(), nil)
+			if err != nil {
+				statusLabel.SetText(fmt.Sprintf("Session error: %v", err))
+				return
+			}
+			r, err := sess.NewReceiver(
+				amqp.LinkSourceAddress(queueEntry.Text),
+				amqp.LinkCredit(uint32(num)),
+			)
+			if err != nil {
+				statusLabel.SetText(fmt.Sprintf("Receiver error: %v", err))
+				return
+			}
+			var lines []string
+			for i := 0; i < num; i++ {
+				msg, err := r.Receive(context.Background(), nil)
+				if err != nil {
+					statusLabel.SetText(fmt.Sprintf("Receive failed: %v", err))
+					break
+				}
+				retrievedMsgs = append(retrievedMsgs, msg)
+				lines = append(lines, string(msg.GetData()[0]))
+			}
+			msgDisplay.SetText(strings.Join(lines, "\n"))
 		}()
 	})
 
@@ -79,10 +156,18 @@ func main() {
 		),
 		connectBtn,
 		statusLabel,
+		widget.NewForm(
+			widget.NewFormItem("Queue", queueEntry),
+			widget.NewFormItem("Count", numEntry),
+		),
+		retrieveBtn,
+		ackBtn,
+		releaseBtn,
+		msgDisplay,
 	)
 
 	w.SetContent(form)
-	w.Resize(fyne.NewSize(400, 200))
+	w.Resize(fyne.NewSize(400, 400))
 
 	w.ShowAndRun()
 }


### PR DESCRIPTION
## Summary
- connect function now returns an AMQP connection
- track retrieved messages in memory
- allow queue name and count to fetch messages
- add buttons to acknowledge or release messages
- document the new feature

## Testing
- `go vet ./...` *(fails: Get "https://proxy.golang.org/...": Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6867b6fea278832191551f7e73322677